### PR TITLE
Remove unneeded OLS scan

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -45,7 +45,6 @@
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/6753</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/display.php?id=projectID3e20b3c3aa052</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/102499762</dc:source>
 		<meta property="se:word-count">53606</meta>
 		<meta property="se:reading-ease.flesch">75.2</meta>


### PR DESCRIPTION
He started with an OLS scan, but found a Hahitrust scan, added it to the metadata during the review process, and it appears to be complete. (It's where he got the dedication and preface.) That would appear to make the OLS scan redundant, so I just removed it.